### PR TITLE
Keep notification persistence when browser tab is inactive

### DIFF
--- a/src/components/dashboard/notifications-dropdown.tsx
+++ b/src/components/dashboard/notifications-dropdown.tsx
@@ -23,28 +23,26 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useToast } from "@/components/ui/use-toast";
 import useWebSocket from "@/hooks/use-websocket";
 import {
   getUnReadNotificationsByUserId,
   markNotificationsAsRead,
 } from "@/lib/actions/notifications.action";
-import { formatDateTime, formatDateTimeDistanceToNow } from "@/lib/datetime";
 import { cn } from "@/lib/utils";
 import { useError } from "@/providers/error-provider";
 import { NotificationDTO, NotificationType } from "@/types/commons";
+
+const LOCAL_STORAGE_KEY = "notifications";
 
 const NotificationsDropdown = () => {
   const { data: session } = useSession();
   const { setError } = useError();
   const { toast } = useToast();
 
-  const [notifications, setNotifications] = useState<NotificationDTO[]>([]);
+  const [notifications, setNotifications] = useState<NotificationDTO[]>(() => {
+    return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]");
+  });
 
   // Load WebSocket notifications
   const { notifications: notificationsSocket } = useWebSocket();
@@ -55,64 +53,90 @@ const NotificationsDropdown = () => {
       if (!session?.user?.id) return;
 
       const notificationsData = await getUnReadNotificationsByUserId(
-        Number(session.user.id),
-        setError,
+          Number(session.user.id),
+          setError
       );
-      setNotifications(notificationsData);
+
+      setNotifications((prev) => {
+        const merged = [
+          ...notificationsData,
+          ...prev.filter((n) => !notificationsData.some((dbN) => dbN.id === n.id)),
+        ];
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(merged));
+        return merged;
+      });
     }
 
     fetchNotifications();
   }, [session]);
 
-  // Merge WebSocket notifications + show toast alerts
+  // Handle WebSocket messages and store them
   useEffect(() => {
     if (notificationsSocket.length > 0) {
       notificationsSocket.forEach((notification) => {
-        toast({
-          title: notification.content,
-        });
+        toast({ title: notification.content });
       });
 
-      // Merge WebSocket notifications while avoiding duplicates
-      setNotifications((prev) => [
-        ...notificationsSocket,
-        ...prev.filter(
-          (n) => !notificationsSocket.some((socketN) => socketN.id === n.id),
-        ),
-      ]);
+      setNotifications((prev) => {
+        const updated = [
+          ...notificationsSocket,
+          ...prev.filter((n) => !notificationsSocket.some((socketN) => socketN.id === n.id)),
+        ];
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
     }
   }, [notificationsSocket]);
 
-  // Mark notification as read when clicked
-  const handleNotificationClick = async (notificationId: number) => {
-    await markNotificationsAsRead([notificationId], setError);
+  // Sync notifications when the tab becomes active
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        setNotifications(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]"));
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, []);
 
-    setNotifications((prevNotifications) =>
-      prevNotifications.map((notification) =>
-        notification.id === notificationId
-          ? { ...notification, isRead: true }
-          : notification,
-      ),
-    );
+  // ✅ Fix: Filter out `null` IDs before marking notifications as read
+  const handleMarkAllRead = async () => {
+    const validNotificationIds = notifications
+        .map((n) => n.id)
+        .filter((id): id is number => id !== null);
 
-    // Remove the notification after a short delay
-    setTimeout(() => {
-      setNotifications((prevNotifications) =>
-        prevNotifications.filter(
-          (notification) => notification.id !== notificationId,
-        ),
-      );
-    }, 500);
+    if (validNotificationIds.length > 0) {
+      await markNotificationsAsRead(validNotificationIds, setError);
+    }
+
+    // ✅ Remove all notifications (both valid & null IDs) from UI and storage
+    setNotifications([]);
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify([]));
   };
 
-  // Mark all notifications as read
-  const handleMarkAllRead = async () => {
-    const notificationIds = notifications
-      .map((n) => n.id)
-      .filter((id): id is number => id !== null);
+  // ✅ Fix: Only remove the notification with a valid ID
+  const handleNotificationClick = async (notificationId: number | null) => {
+    if (notificationId === null) return; // Prevent errors
 
-    await markNotificationsAsRead(notificationIds, setError);
-    setNotifications([]); // Clear notifications from UI
+    await markNotificationsAsRead([notificationId], setError);
+
+    setNotifications((prevNotifications) => {
+      const updated = prevNotifications.map((notification) =>
+          notification.id === notificationId
+              ? { ...notification, isRead: true }
+              : notification
+      );
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+
+    setTimeout(() => {
+      setNotifications((prevNotifications) => {
+        const updated = prevNotifications.filter((notification) => notification.id !== notificationId);
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+        return updated;
+      });
+    }, 500);
   };
 
   const getNotificationIcon = (type: NotificationType) => {
@@ -120,143 +144,68 @@ const NotificationsDropdown = () => {
       case NotificationType.INFO:
         return <Bell className="text-blue-500 dark:text-blue-400 w-5 h-5" />;
       case NotificationType.WARNING:
-        return (
-          <AlertTriangle className="text-yellow-500 dark:text-yellow-400 w-5 h-5" />
-        );
+        return <AlertTriangle className="text-yellow-500 dark:text-yellow-400 w-5 h-5" />;
       case NotificationType.ERROR:
         return <XCircle className="text-red-500 dark:text-red-400 w-5 h-5" />;
       case NotificationType.SLA_BREACH:
-        return (
-          <Clock className="text-orange-500 dark:text-orange-400 w-5 h-5" />
-        );
+        return <Clock className="text-orange-500 dark:text-orange-400 w-5 h-5" />;
       case NotificationType.SLA_WARNING:
-        return (
-          <Timer className="text-purple-500 dark:text-purple-400 w-5 h-5" />
-        );
+        return <Timer className="text-purple-500 dark:text-purple-400 w-5 h-5" />;
       case NotificationType.ESCALATION_NOTICE:
-        return (
-          <ArrowUpCircle className="text-green-500 dark:text-green-400 w-5 h-5" />
-        );
+        return <ArrowUpCircle className="text-green-500 dark:text-green-400 w-5 h-5" />;
       default:
         return <Bell className="text-gray-500 dark:text-gray-400 w-5 h-5" />;
     }
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" className="relative h-8 w-8 rounded-full">
-          <BellDot className="animate-tada h-5 w-5" />
-          {notifications.length > 0 && (
-            <div
-              className={cn(
-                "absolute top-[2px] right-[2px] translate-x-1/2 translate-y-[-50%]",
-                "w-5 h-5 text-[10px] rounded-full font-semibold flex items-center justify-center",
-                "bg-red-400 text-white",
-                "dark:bg-red-500 dark:text-white",
-              )}
-            >
-              {notifications.length}
-            </div>
-          )}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        className={cn(
-          "z-[999] mx-4 lg:w-[24rem] p-0",
-          "bg-[rgba(255,255,255,0.9)] dark:bg-[rgba(23,23,23,0.8)]",
-          "border border-[hsl(var(--border))] dark:border-[hsl(var(--border-dark))]",
-          "backdrop-blur-md backdrop-brightness-110 dark:backdrop-brightness-75 shadow-lg",
-        )}
-      >
-        {notifications.length > 0 ? (
-          <>
-            <DropdownMenuLabel>
-              <div className="flex justify-between px-2 py-2">
-                <div className="text-sm text-default-800 dark:text-default-200 font-medium">
-                  Notifications ({notifications.length})
-                </div>
-                <Button
-                  variant="link"
-                  onClick={handleMarkAllRead}
-                  className="text-sm px-0 h-0"
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="relative h-8 w-8 rounded-full">
+            <BellDot className="animate-tada h-5 w-5" />
+            {notifications.length > 0 && (
+                <div
+                    className={cn(
+                        "absolute top-[2px] right-[2px] translate-x-1/2 translate-y-[-50%]",
+                        "w-5 h-5 text-[10px] rounded-full font-semibold flex items-center justify-center",
+                        "bg-red-400 text-white",
+                        "dark:bg-red-500 dark:text-white"
+                    )}
                 >
-                  Mark all read
-                </Button>
-              </div>
-            </DropdownMenuLabel>
-            <div className="max-h-[16rem] xl:max-h-[20rem] overflow-auto">
-              <ScrollArea className="h-full">
-                <AnimatePresence>
-                  {notifications.map((item: NotificationDTO) => (
-                    <motion.div
-                      key={item.id}
-                      initial={{ opacity: 1, y: 0 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -20 }}
-                      transition={{ duration: 0.5 }}
-                      className={cn(
-                        "border-t border-[hsl(var(--border))] dark:border-[hsl(var(--border-dark))]",
-                        item.isRead
-                          ? "bg-gray-100 dark:bg-gray-800"
-                          : "bg-white dark:bg-black",
-                      )}
-                    >
-                      <DropdownMenuItem
-                        onSelect={(e) => e.preventDefault()}
-                        className={cn(
-                          "flex gap-9 py-2 px-4 cursor-pointer group",
-                          "hover:bg-[hsl(var(--muted))] dark:hover:bg-[rgba(255,255,255,0.05)]",
-                        )}
-                        onClick={() => handleNotificationClick(item.id!)}
-                      >
-                        <div className="flex items-start gap-3 flex-1">
-                          {/* ✅ Wrap icon in a fixed-width div to prevent shifting */}
-                          <div className="w-6 flex items-center justify-center">
+                  {notifications.length}
+                </div>
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="z-[999] mx-4 lg:w-[24rem] p-0">
+          {notifications.length > 0 ? (
+              <>
+                <DropdownMenuLabel>
+                  <div className="flex justify-between px-2 py-2">
+                    <div className="text-sm font-medium">Notifications ({notifications.length})</div>
+                    <Button variant="link" onClick={handleMarkAllRead} className="text-sm px-0 h-0">
+                      Mark all read
+                    </Button>
+                  </div>
+                </DropdownMenuLabel>
+                <ScrollArea className="max-h-[20rem]">
+                  <AnimatePresence>
+                    {notifications.map((item) => (
+                        <motion.div key={item.id} exit={{ opacity: 0, y: -20 }} transition={{ duration: 0.5 }}>
+                          <DropdownMenuItem onClick={() => handleNotificationClick(item.id)} className="flex gap-3">
                             {getNotificationIcon(item.type)}
-                          </div>
-
-                          {/* ✅ Wrap content and date inside the same flex container */}
-                          <div className="flex-1 flex flex-col gap-0.5 -mx-4">
-                            <div className="html-display">
-                              <TruncatedHtmlLabel
-                                htmlContent={item.content}
-                                wordLimit={400}
-                              />
-                            </div>
-                            <div className="text-sm text-gray-500 dark:text-gray-400">
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  {formatDateTimeDistanceToNow(
-                                    new Date(item.createdAt),
-                                  )}
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  <p>
-                                    {formatDateTime(new Date(item.createdAt))}
-                                  </p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </div>
-                          </div>
-                        </div>
-                      </DropdownMenuItem>
-                    </motion.div>
-                  ))}
-                </AnimatePresence>
-              </ScrollArea>
-            </div>
-          </>
-        ) : (
-          <div className="flex items-center justify-center p-4">
-            <p className="text-sm text-default-800 dark:text-default-200">
-              You have no notifications.
-            </p>
-          </div>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+                            <TruncatedHtmlLabel htmlContent={item.content} wordLimit={400} />
+                          </DropdownMenuItem>
+                        </motion.div>
+                    ))}
+                  </AnimatePresence>
+                </ScrollArea>
+              </>
+          ) : (
+              <div className="p-4 text-center text-sm">No notifications.</div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
   );
 };
 

--- a/src/components/dashboard/notifications-dropdown.tsx
+++ b/src/components/dashboard/notifications-dropdown.tsx
@@ -23,13 +23,18 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useToast } from "@/components/ui/use-toast";
 import useWebSocket from "@/hooks/use-websocket";
 import {
   getUnReadNotificationsByUserId,
   markNotificationsAsRead,
 } from "@/lib/actions/notifications.action";
-import { cn } from "@/lib/utils";
+import { formatDateTime, formatDateTimeDistanceToNow } from "@/lib/datetime";
 import { useError } from "@/providers/error-provider";
 import { NotificationDTO, NotificationType } from "@/types/commons";
 
@@ -44,23 +49,23 @@ const NotificationsDropdown = () => {
     return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]");
   });
 
-  // Load WebSocket notifications
   const { notifications: notificationsSocket } = useWebSocket();
 
-  // Load unread notifications from the database
   useEffect(() => {
     async function fetchNotifications() {
       if (!session?.user?.id) return;
 
       const notificationsData = await getUnReadNotificationsByUserId(
-          Number(session.user.id),
-          setError
+        Number(session.user.id),
+        setError,
       );
 
       setNotifications((prev) => {
         const merged = [
           ...notificationsData,
-          ...prev.filter((n) => !notificationsData.some((dbN) => dbN.id === n.id)),
+          ...prev.filter(
+            (n) => !notificationsData.some((dbN) => dbN.id === n.id),
+          ),
         ];
         localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(merged));
         return merged;
@@ -70,7 +75,6 @@ const NotificationsDropdown = () => {
     fetchNotifications();
   }, [session]);
 
-  // Handle WebSocket messages and store them
   useEffect(() => {
     if (notificationsSocket.length > 0) {
       notificationsSocket.forEach((notification) => {
@@ -80,7 +84,9 @@ const NotificationsDropdown = () => {
       setNotifications((prev) => {
         const updated = [
           ...notificationsSocket,
-          ...prev.filter((n) => !notificationsSocket.some((socketN) => socketN.id === n.id)),
+          ...prev.filter(
+            (n) => !notificationsSocket.some((socketN) => socketN.id === n.id),
+          ),
         ];
         localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
         return updated;
@@ -88,43 +94,43 @@ const NotificationsDropdown = () => {
     }
   }, [notificationsSocket]);
 
-  // Sync notifications when the tab becomes active
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        setNotifications(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]"));
+        setNotifications(
+          JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]"),
+        );
       }
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, []);
 
-  // ✅ Fix: Filter out `null` IDs before marking notifications as read
   const handleMarkAllRead = async () => {
     const validNotificationIds = notifications
-        .map((n) => n.id)
-        .filter((id): id is number => id !== null);
+      .map((n) => n.id)
+      .filter((id): id is number => id !== null);
 
     if (validNotificationIds.length > 0) {
       await markNotificationsAsRead(validNotificationIds, setError);
     }
 
-    // ✅ Remove all notifications (both valid & null IDs) from UI and storage
     setNotifications([]);
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify([]));
   };
 
-  // ✅ Fix: Only remove the notification with a valid ID
-  const handleNotificationClick = async (notificationId: number | null) => {
-    if (notificationId === null) return; // Prevent errors
-
-    await markNotificationsAsRead([notificationId], setError);
+  const handleNotificationClick = async (
+    notificationId: number | null,
+    index: number,
+  ) => {
+    if (notificationId !== null) {
+      await markNotificationsAsRead([notificationId], setError);
+    }
 
     setNotifications((prevNotifications) => {
-      const updated = prevNotifications.map((notification) =>
-          notification.id === notificationId
-              ? { ...notification, isRead: true }
-              : notification
+      const updated = prevNotifications.map((notification, i) =>
+        i === index ? { ...notification, isRead: true } : notification,
       );
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
       return updated;
@@ -132,7 +138,7 @@ const NotificationsDropdown = () => {
 
     setTimeout(() => {
       setNotifications((prevNotifications) => {
-        const updated = prevNotifications.filter((notification) => notification.id !== notificationId);
+        const updated = prevNotifications.filter((_, i) => i !== index);
         localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
         return updated;
       });
@@ -144,68 +150,100 @@ const NotificationsDropdown = () => {
       case NotificationType.INFO:
         return <Bell className="text-blue-500 dark:text-blue-400 w-5 h-5" />;
       case NotificationType.WARNING:
-        return <AlertTriangle className="text-yellow-500 dark:text-yellow-400 w-5 h-5" />;
+        return (
+          <AlertTriangle className="text-yellow-500 dark:text-yellow-400 w-5 h-5" />
+        );
       case NotificationType.ERROR:
         return <XCircle className="text-red-500 dark:text-red-400 w-5 h-5" />;
       case NotificationType.SLA_BREACH:
-        return <Clock className="text-orange-500 dark:text-orange-400 w-5 h-5" />;
+        return (
+          <Clock className="text-orange-500 dark:text-orange-400 w-5 h-5" />
+        );
       case NotificationType.SLA_WARNING:
-        return <Timer className="text-purple-500 dark:text-purple-400 w-5 h-5" />;
+        return (
+          <Timer className="text-purple-500 dark:text-purple-400 w-5 h-5" />
+        );
       case NotificationType.ESCALATION_NOTICE:
-        return <ArrowUpCircle className="text-green-500 dark:text-green-400 w-5 h-5" />;
+        return (
+          <ArrowUpCircle className="text-green-500 dark:text-green-400 w-5 h-5" />
+        );
       default:
         return <Bell className="text-gray-500 dark:text-gray-400 w-5 h-5" />;
     }
   };
 
   return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="relative h-8 w-8 rounded-full">
-            <BellDot className="animate-tada h-5 w-5" />
-            {notifications.length > 0 && (
-                <div
-                    className={cn(
-                        "absolute top-[2px] right-[2px] translate-x-1/2 translate-y-[-50%]",
-                        "w-5 h-5 text-[10px] rounded-full font-semibold flex items-center justify-center",
-                        "bg-red-400 text-white",
-                        "dark:bg-red-500 dark:text-white"
-                    )}
-                >
-                  {notifications.length}
-                </div>
-            )}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="z-[999] mx-4 lg:w-[24rem] p-0">
-          {notifications.length > 0 ? (
-              <>
-                <DropdownMenuLabel>
-                  <div className="flex justify-between px-2 py-2">
-                    <div className="text-sm font-medium">Notifications ({notifications.length})</div>
-                    <Button variant="link" onClick={handleMarkAllRead} className="text-sm px-0 h-0">
-                      Mark all read
-                    </Button>
-                  </div>
-                </DropdownMenuLabel>
-                <ScrollArea className="max-h-[20rem]">
-                  <AnimatePresence>
-                    {notifications.map((item) => (
-                        <motion.div key={item.id} exit={{ opacity: 0, y: -20 }} transition={{ duration: 0.5 }}>
-                          <DropdownMenuItem onClick={() => handleNotificationClick(item.id)} className="flex gap-3">
-                            {getNotificationIcon(item.type)}
-                            <TruncatedHtmlLabel htmlContent={item.content} wordLimit={400} />
-                          </DropdownMenuItem>
-                        </motion.div>
-                    ))}
-                  </AnimatePresence>
-                </ScrollArea>
-              </>
-          ) : (
-              <div className="p-4 text-center text-sm">No notifications.</div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="relative h-8 w-8 rounded-full">
+          <BellDot className="animate-tada h-5 w-5" />
+          {notifications.length > 0 && (
+            <div className="absolute top-[2px] right-[2px] translate-x-1/2 translate-y-[-50%] w-5 h-5 text-[10px] rounded-full font-semibold flex items-center justify-center bg-red-400 text-white dark:bg-red-500 dark:text-white">
+              {notifications.length}
+            </div>
           )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="z-[999] mx-4 lg:w-[24rem] p-0"
+      >
+        {notifications.length > 0 ? (
+          <>
+            <DropdownMenuLabel>
+              <div className="flex justify-between px-2 py-2">
+                <div className="text-sm font-medium">
+                  Notifications ({notifications.length})
+                </div>
+                <Button
+                  variant="link"
+                  onClick={handleMarkAllRead}
+                  className="text-sm px-0 h-0"
+                >
+                  Mark all read
+                </Button>
+              </div>
+            </DropdownMenuLabel>
+            <ScrollArea className="max-h-[20rem] overflow-y-auto">
+              <AnimatePresence>
+                {notifications.map((item, index) => (
+                  <motion.div
+                    key={index}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.5 }}
+                  >
+                    <DropdownMenuItem
+                      className="cursor-pointer flex gap-3 items-start"
+                      onClick={() => handleNotificationClick(item.id, index)}
+                    >
+                      {getNotificationIcon(item.type)}
+                      <div className="flex-1 flex flex-col">
+                        <TruncatedHtmlLabel
+                          htmlContent={item.content}
+                          wordLimit={400}
+                        />
+                        <Tooltip>
+                          <TooltipTrigger className="w-auto text-left">
+                            {formatDateTimeDistanceToNow(
+                              new Date(item.createdAt),
+                            )}
+                          </TooltipTrigger>
+                          <TooltipContent side="right" align="start">
+                            <p>{formatDateTime(new Date(item.createdAt))}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </DropdownMenuItem>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </ScrollArea>
+          </>
+        ) : (
+          <div className="p-4 text-center text-sm">No new notifications.</div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/src/components/shared/truncate-html-label.tsx
+++ b/src/components/shared/truncate-html-label.tsx
@@ -10,7 +10,10 @@ const TruncatedHtmlLabel = ({
   if (htmlContent.length <= wordLimit) {
     return (
       <div className="px-4">
-        <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+        <div
+          className="prose prose-blue dark:prose-invert max-w-none"
+          dangerouslySetInnerHTML={{ __html: htmlContent }}
+        />
       </div>
     );
   }
@@ -20,10 +23,11 @@ const TruncatedHtmlLabel = ({
   return (
     <div className="px-4">
       <div
-        className="prose max-w-none"
+        className="prose prose-blue dark:prose-invert max-w-none"
         dangerouslySetInnerHTML={{ __html: truncatedContent }}
       />
     </div>
   );
 };
+
 export default TruncatedHtmlLabel;


### PR DESCRIPTION
## Description

This update brings two key improvements:

Enhances notification handling by ensuring the dropdown can mark notifications as read, even if some have a null ID, following up on [PR #72](https://github.com/flowinquiry/flowinquiry-server/pull/72).
Maintains notification persistence when the browser tab is inactive, preventing missed updates.

## Changes Made

<!-- List the main changes made in this PR. Use bullet points for clarity. -->

## Additional Notes

<!-- Add any other context or information that reviewers may need. -->
